### PR TITLE
fix: gate publish steps on releases_created

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -16,17 +16,17 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v6
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.release.outputs.releases_created }}
 
       - name: Build and publish to GitHub Package
         uses: actionshub/publish-gem-to-github@main
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.release.outputs.releases_created }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           owner: ${{ secrets.OWNER }}
 
       - name: Build and publish to RubyGems
         uses: actionshub/publish-gem-to-rubygems@main
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.release.outputs.releases_created }}
         with:
           token: ${{ secrets.RUBYGEMS_API_KEY }}


### PR DESCRIPTION
# Description

This changes the publish gate from `steps.release.outputs.release_created` to `steps.release.outputs.releases_created`. The workflow should only run `Checkout`, `Build and publish to GitHub Package`, and `Build and publish to RubyGems` when the current [release-please](https://github.com/googleapis/release-please-action/blob/0b6b3fc0186a2f7118bfd88fab9ea481e1839504/src/index.ts) run actually creates a GitHub release. In the action code, `releases_created` is the direct run-level signal set from the result of [manifest.createReleases()](https://github.com/googleapis/release-please-action/blob/0b6b3fc0186a2f7118bfd88fab9ea481e1839504/src/index.ts#L144) in [index.ts:186](https://github.com/googleapis/release-please-action/blob/0b6b3fc0186a2f7118bfd88fab9ea481e1839504/src/index.ts#L186) and [index.ts:189](https://github.com/googleapis/release-please-action/blob/0b6b3fc0186a2f7118bfd88fab9ea481e1839504/src/index.ts#L189). By contrast, `release_created` is a path-specific output that is derived later inside the per-release loop in [index.ts:196](https://github.com/googleapis/release-please-action/blob/0b6b3fc0186a2f7118bfd88fab9ea481e1839504/src/index.ts#L196) and [index.ts:200](https://github.com/googleapis/release-please-action/blob/0b6b3fc0186a2f7118bfd88fab9ea481e1839504/src/index.ts#L200).

This also explains why version `0.6.1` worked while later releases did not. On the `0.6.1` run, the action both created the release and surfaced the root-path `release_created` output in a way that matched the workflow condition, so the downstream publish steps executed. For later runs, the actual releases were still created, but relying on the path-specific `release_created` output was not reliable for gating the publish steps. Since our intent is not path-specific and is simply “did this run create a release?”, `releases_created` is the better signal.

This should be the go-forward solution because it matches the intended workflow behavior exactly:

- when release-please only opens or updates the [chore(main): release ...](file:///Users/john.haggerty%40optum.com/git/googleapis/release-please-action/src/index.ts#191%2C16) PR, publish steps stay skipped
- when that release PR is merged and the run actually creates the GitHub release, publish steps execute

## Check List

- [x] All commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format
  - **Required**: This triggers our automated CHANGELOG and release pipeline (release-please)
  - **Without conventional commits, your changes cannot be released**
  - Examples: `fix: resolve bug in resource`, `feat: add new property`, `docs: update README`
- [ ] New functionality includes testing
- [ ] New functionality has been documented in the README if applicable

## ⚠️ Important: Automated Release Workflow

**DO NOT manually edit these files:**

- ❌ `metadata.rb` version - Managed by release-please
- ❌ `CHANGELOG.md` - Auto-generated from conventional commits
- ❌ Version tags - Created automatically on release

**The release process:**

1. Merge PR with conventional commits → release-please creates a release PR
2. Merge release PR → automatic version bump, CHANGELOG update, and Supermarket publish
3. Your changes are released! 🎉

**Need help?** See [Conventional Commits guide](https://www.conventionalcommits.org/)
